### PR TITLE
In enter, return the returncode from the process

### DIFF
--- a/vsh/api.py
+++ b/vsh/api.py
@@ -205,7 +205,8 @@ def enter(path, command=None, verbose=None):
     support.echo(click.style(f'Running command in "', fg='blue') + venv_name + click.style(f'": ', fg='blue') + cmd_display, verbose=max(verbose - 1, 0))
 
     # Activate and run
-    return_code = subprocess.run(command, shell=True, env=env, universal_newlines=True)
+    completed_process = subprocess.run(command, shell=True, env=env, universal_newlines=True)
+    return_code = completed_process.returncode
     rc_color = 'green' if return_code == 0 else 'red'
     rc = click.style(str(return_code), fg=rc_color)
     support.echo(click.style('Command return code: ', fg='blue') + rc, verbose=verbose)


### PR DESCRIPTION
subprocess.run returns a CompletedProcess object, not a return code.

This fixes the printing that happens at the end of a call:

Before:
```
code » vsh test ls
[...]
CompletedProcess(args='/bin/zsh -i -c "source /home/jobevers/.virtualenvs/test/.vshrc; ls"', returncode=0)
code »
```

After:
```
code » vsh test ls
[...]
code »
```